### PR TITLE
spring-open-api 설정 추가

### DIFF
--- a/drink-api/src/main/java/com/example/openapi/OpenApiConfig.java
+++ b/drink-api/src/main/java/com/example/openapi/OpenApiConfig.java
@@ -1,0 +1,16 @@
+package com.example.openapi;
+
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.bson.types.ObjectId;
+import org.springdoc.core.SpringDocUtils;
+
+public class OpenApiConfig {
+
+    static {
+        /*
+         * spring-open-api 에서 변수 타입이 ObjectId인 경우,
+         * String 타입으로 매핑
+         */
+        SpringDocUtils.getConfig().replaceWithSchema(ObjectId.class, new StringSchema());
+    }
+}

--- a/drink-api/src/main/java/com/example/openapi/OpenApiConfig.java
+++ b/drink-api/src/main/java/com/example/openapi/OpenApiConfig.java
@@ -3,7 +3,9 @@ package com.example.openapi;
 import io.swagger.v3.oas.models.media.StringSchema;
 import org.bson.types.ObjectId;
 import org.springdoc.core.SpringDocUtils;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class OpenApiConfig {
 
     static {


### PR DESCRIPTION
### 이슈
- open-api 문서를 생성하는 경우, ObjectId 타입은 javadoc가 적용되지 않고, 
   date , timestamp 타입으로 표시되는 이슈 처리
### 설정 추가
-  ObjectId 타입을 String 으로 변경 설정 추가#40 
### REF
- [적용 가이드](https://stackoverflow.com/questions/58375613/swagger-shows-mongo-objectid-as-complex-json-instead-of-string)