### PR TITLE
* cash-api 프로젝트 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ subprojects {
         implementation 'org.springdoc:springdoc-openapi-ui:1.6.10'
         implementation 'org.springdoc:springdoc-openapi-javadoc:1.6.10'
         implementation 'com.github.therapi:therapi-runtime-javadoc:0.15.0'
+        implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.testcontainers:testcontainers:1.16.3'

--- a/cash-api/src/main/java/com/example/openapi/OpenApiConfig.java
+++ b/cash-api/src/main/java/com/example/openapi/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.example.openapi;
+
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.bson.types.ObjectId;
+import org.springdoc.core.SpringDocUtils;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    static {
+        /*
+         * spring-open-api 에서 변수 타입이 ObjectId인 경우,
+         * String 타입으로 매핑
+         */
+        SpringDocUtils.getConfig().replaceWithSchema(ObjectId.class, new StringSchema());
+    }
+}

--- a/drink-api/build.gradle
+++ b/drink-api/build.gradle
@@ -9,7 +9,6 @@ version = 'v01'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
     testImplementation 'org.testcontainers:mongodb:1.17.2'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'vending-machine'
 include 'drink-api'
 include 'application'
+include 'cash-api'
+


### PR DESCRIPTION
### cash-api
> - cash-api 패키지 구조 생성


```
com.example.cash
com.example.transaction
com.example.mongo
com.example.openapi
```

### gradle
> - spring mongo 라이브러리 공통으로 뻄

추후에는 mongo와 openapi 같은 공통 모듈을 뺴는걸로