### PR TITLE
Cash deposit 관련 테스트 케이스 리팩토링

### DIFF
--- a/cash-api/src/test/kotlin/com/example/cash/controller/CashControllerTest.kt
+++ b/cash-api/src/test/kotlin/com/example/cash/controller/CashControllerTest.kt
@@ -48,19 +48,20 @@ class CashControllerUnitTest(
             }
         }
 
-        When("입금하기 정상 처리된 경우") {
+        val balance = 1000
+        When("지갑 잔액이 " +balance+ "원인 상태에서 입금하기 정상 처리된 경우") {
             val amount = 1000L
             val payload = CashDepositPayLoad(amount)
-            val expected = CashDepositView(amount)
+            val expected = CashDepositView(balance + amount)
             every { cashService.deposit(amount) } returns expected
             val exchange = cashDepositClient(payload)
                 .exchange()
             Then("status: 200 Ok") {
                 exchange.expectStatus().isOk
             }
-            Then("body: balance 는 1000원이다.") {
+            Then("body: balance 는 "+(balance + amount)+"원이 된다.") {
                 exchange.expectBody<CashDepositView>().returnResult()
-                    .responseBody!!.balance shouldBe amount
+                    .responseBody!!.balance shouldBe (balance + amount)
             }
         }
     }

--- a/cash-api/src/test/kotlin/com/example/cash/repo/CashRepositoryTest.kt
+++ b/cash-api/src/test/kotlin/com/example/cash/repo/CashRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.example.mongo.model.Cash
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import java.util.*
 
 @DataMongoTest
 class CashRepositoryTest(
@@ -53,4 +54,14 @@ class CashRepositoryTest(
             }
         }
     }
+
+    Given("cash 데이터가 db에 존재하지 않을떄") {
+        When("cash 데이터를 조회하면") {
+            val cash : Optional<Cash> = cashRepository.findFirstBy()
+            Then("Optional.empty 상태를 반환한다.") {
+                cash shouldBe Optional.empty()
+            }
+        }
+    }
+
 })

--- a/cash-api/src/test/kotlin/com/example/cash/service/CashServiceTest.kt
+++ b/cash-api/src/test/kotlin/com/example/cash/service/CashServiceTest.kt
@@ -4,12 +4,14 @@ import com.example.cash.repo.CashRepository
 import com.example.mongo.model.Cash
 import com.example.mongo.model.Transaction
 import com.example.transaction.service.TransactionServiceImpl
+import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import java.util.*
+import kotlin.NoSuchElementException
 
 class CashServiceTest : BehaviorSpec({
 
@@ -23,9 +25,32 @@ class CashServiceTest : BehaviorSpec({
     }
 
     Given("cashService deposit 테스트") {
-        When("자판기의 잔액이 1000원인 상태에서 1000원을 추가로 넣으면") {
-            val amount = 1000L
-            val cash = Cash.of(amount)
+
+        val amount = 1000L
+        val balance = 1000L
+        When("자판기의 잔액 데이터가 존재하지 않을때 "+amount+"원을 입금을 하면") {
+
+            val cash : Optional<Cash> = Optional.empty()
+
+            every {
+                cashRepository.findFirstBy()
+            } returns cash
+
+            every {
+                transactionServiceImpl.deposit(amount)
+            } returns Transaction.ofDeposit(amount)
+
+            val exception = shouldThrowExactly<NoSuchElementException> {
+                cashService.deposit(amount)
+            }
+
+            Then("java.util.NoSuchElementException: No value present 오류가 발생한다.") {
+                exception.message shouldBe "No value present"
+            }
+        }
+
+        When("자판기의 잔액이 "+ balance +"원인 상태에서 "+ amount + "원을 추가로 입금하면") {
+            val cash = Cash.of(balance)
             val depositCash = cash.deposit(amount)
             val expected = depositCash.toCashDepositView()
 
@@ -42,7 +67,7 @@ class CashServiceTest : BehaviorSpec({
             } returns depositCash
 
             val cashDepositView = cashService.deposit(amount)
-            Then("2000원의 잔액 결과를 반환한다. (또한 1000원에 해당하는 거래 내역을 생성한다.)") {
+            Then(""+expected.balance+"원의 잔액 결과를 반환한다.") {
                 cashDepositView.balance shouldBe expected.balance
             }
         }


### PR DESCRIPTION
1. 어제 말씀하신대로 명세의 목적도 있지만 값을 변경하면서 테스트 하는(디버깅 최소화) 목적도 있다고 생각해서 변수 값에 따라 명세가 변경되고 결과 또한 변경되도록 테스트 로직을 수정했습니다.

2. service에서 Cash 데이터가 초기화 된상태가 아닐때의 에러 케이스도 추가 했습니다.

3. 테스트 전반적으로 입금 결과값이 amount로 되어 있어 수정 했습니다. 결과 값이 잔액 + 요청한 값이 되어야 하므로 balance + amount 형태로 테스트 결과를 변경 했습니다.