### PR TITLE
[#104] 에러 메시지 정의 개선

### DIFF
--- a/cash-api/src/main/java/com/example/ExceptionTranslator.java
+++ b/cash-api/src/main/java/com/example/ExceptionTranslator.java
@@ -27,6 +27,6 @@ public class ExceptionTranslator {
     public ResponseEntity<ErrorBody> exception(Exception exception){
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorBody.of(exception));
+                .body(ErrorBody.of());
     }
 }

--- a/cash-api/src/main/java/com/example/error/ErrorBody.java
+++ b/cash-api/src/main/java/com/example/error/ErrorBody.java
@@ -1,10 +1,7 @@
 package com.example.error;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
@@ -14,19 +11,20 @@ import java.util.stream.Collectors;
 
 @Data
 @AllArgsConstructor
+@RequiredArgsConstructor
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class ErrorBody {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private String message;
+    private final String message;
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    private int code;
+    private String code;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<SimpleFieldError> fields;
 
-    private long timestamp;
+    private long timestamp = Instant.now().toEpochMilli();
 
     /**
      * 에러 바디 객체 생성 함수 (MethodArgumentNotValidException)
@@ -34,17 +32,15 @@ public class ErrorBody {
      */
     public static ErrorBody of(MethodArgumentNotValidException exception) {
         List<SimpleFieldError> fields = exception.getBindingResult().getFieldErrors().stream().map(SimpleFieldError::of).collect(Collectors.toList());
-        long timeStamp = Instant.now().toEpochMilli();
-        return new ErrorBody(ErrorMessage.INVALID_VALIDATION, HttpStatus.BAD_REQUEST.value(), fields, timeStamp);
+        ErrorBody body = new ErrorBody(ErrorMessage.INVALID_VALIDATION);
+        body.fields = fields;
+        return body;
     }
-
 
     /**
      * 에러 바디 객체 생성 함수 (EXCEPTION)
-     * @param exception @ModelAttribute 나 @RequestBody 유효성 검사 실패시 발생하는 예외
      */
-    public static ErrorBody of(Exception exception) {
-        long timeStamp = Instant.now().toEpochMilli();
-        return new ErrorBody(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),HttpStatus.INTERNAL_SERVER_ERROR.value(),null,timeStamp);
+    public static ErrorBody of() {
+        return new ErrorBody(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
     }
 }

--- a/cash-api/src/test/kotlin/com/example/cash/controller/CashControllerTest.kt
+++ b/cash-api/src/test/kotlin/com/example/cash/controller/CashControllerTest.kt
@@ -54,15 +54,15 @@ class CashControllerUnitTest(
             val payload = CashDepositPayLoad(amount)
             val exchange = cashDepositClient(payload)
                 .exchange()
-            val expected = HttpStatus.INTERNAL_SERVER_ERROR.value()
+            val expected = HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase
+
+            every { cashService.deposit(amount) } throws Exception()
 
             Then("status: 500 Internal Server Error") {
                 exchange.expectStatus().is5xxServerError
             }
-            Then("body: status는 server error") {
-                exchange.expectBody<ErrorBody>().returnResult().responseBody!!.should {errorBody ->
-                    errorBody.code shouldBe expected
-                }
+            Then("body: message" + expected + "이다") {
+                exchange.expectBody<ErrorBody>().returnResult().responseBody!!.message shouldBe expected
             }
         }
 

--- a/cash-api/src/test/kotlin/com/example/config/DbExtension.kt
+++ b/cash-api/src/test/kotlin/com/example/config/DbExtension.kt
@@ -1,4 +1,4 @@
-package com.example.transaction.config
+package com.example.config
 
 import io.kotest.core.annotation.AutoScan
 import io.kotest.core.listeners.AfterProjectListener

--- a/cash-api/src/test/kotlin/com/example/config/KotestProjectConfig.kt
+++ b/cash-api/src/test/kotlin/com/example/config/KotestProjectConfig.kt
@@ -1,4 +1,4 @@
-package com.example.transaction.config
+package com.example.config
 
 import io.kotest.core.config.AbstractProjectConfig
 


### PR DESCRIPTION
## 요약
### ErrorBody
- code 는 커스텀 에러 코드 정의시 사용 
  ex)`invalid_email` ..
- 생성자 선언시 반드시 필요한 필드만 적용

### TODO
- cash-api 만 적용된 상태이니 다른 프로젝트에도 적용이 필요함