### PR TITLE
[#110] cash 거스름돈 service 구현

### DIFF
--- a/cash-api/src/main/java/com/example/cash/controller/CashController.java
+++ b/cash-api/src/main/java/com/example/cash/controller/CashController.java
@@ -34,10 +34,10 @@ public class CashController {
 
     /**
      * 거스름돈 반환
-     * @return
+     * @return CashChangeView
      */
     @Operation(summary = "거스름돈 반환")
-    @PutMapping(value = "/change", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/change", produces = MediaType.APPLICATION_JSON_VALUE)
     public CashChangeView cashChange() {
         return cashService.change();
     }

--- a/cash-api/src/main/java/com/example/cash/service/CashServiceImpl.java
+++ b/cash-api/src/main/java/com/example/cash/service/CashServiceImpl.java
@@ -29,6 +29,17 @@ public class CashServiceImpl implements CashService {
 
     @Override
     public CashChangeView change() {
-        return null;
+        return cashRepository.findFirstBy()
+                .map(cash -> {
+                    transactionService.change(cash.changeReturn());
+                    return cash;
+                }).map(cash -> {
+                    CashChangeView cashChangeView = cash.toCashChangeView();
+                    cashRepository.save(cash.reset());
+                    return cashChangeView;
+                }).orElseThrow();
     }
 }
+
+
+

--- a/cash-api/src/main/java/com/example/mongo/model/Cash.java
+++ b/cash-api/src/main/java/com/example/mongo/model/Cash.java
@@ -1,6 +1,8 @@
 package com.example.mongo.model;
 
+import com.example.cash.dto.CashChangeView;
 import com.example.cash.dto.CashDepositView;
+import com.example.error.exception.CashEmptyException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.bson.types.ObjectId;
@@ -8,6 +10,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
+import org.springframework.http.HttpStatus;
 
 import java.time.Instant;
 
@@ -47,6 +50,10 @@ public class Cash {
         return new Cash(id, balance, createDate, updateDate);
     }
 
+    public Cash reset() {
+        return new Cash(id, 0L, createDate, Instant.now());
+    }
+
     /**
      * 입금하기
      *
@@ -59,9 +66,27 @@ public class Cash {
     }
 
     /**
+     * 거스름돈 반환
+     * @return
+     */
+    public long changeReturn() {
+        if(balance == 0) {
+            throw new CashEmptyException(HttpStatus.NOT_FOUND);
+        }
+        return balance;
+    }
+
+    /**
      * 입금 응답값 변환
      */
     public CashDepositView toCashDepositView() {
         return new CashDepositView(balance);
+    }
+
+    /**
+     * 거스름돈 응답값 변환
+     */
+    public CashChangeView toCashChangeView() {
+        return new CashChangeView(balance);
     }
 }

--- a/cash-api/src/test/kotlin/com/example/cash/service/CashServiceTest.kt
+++ b/cash-api/src/test/kotlin/com/example/cash/service/CashServiceTest.kt
@@ -1,6 +1,7 @@
 package com.example.cash.service
 
 import com.example.cash.repo.CashRepository
+import com.example.error.exception.CashEmptyException
 import com.example.mongo.model.Cash
 import com.example.mongo.model.Transaction
 import com.example.transaction.service.TransactionServiceImpl
@@ -10,8 +11,8 @@ import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import org.springframework.http.HttpStatus
 import java.util.*
-import kotlin.NoSuchElementException
 
 class CashServiceTest : BehaviorSpec({
 
@@ -73,4 +74,49 @@ class CashServiceTest : BehaviorSpec({
         }
     }
 
+    Given("cashService change 테스트") {
+        When("잔액이 0원 일떄 거스름돈을 반환하면") {
+            val cash = Cash.of(0);
+
+            every {
+                cashRepository.findFirstBy()
+            } returns Optional.of(cash)
+
+            every {
+                transactionServiceImpl.change(any())
+            } throws CashEmptyException(HttpStatus.NOT_FOUND)
+
+            val exception = shouldThrowExactly<CashEmptyException> {
+                cashService.change()
+            }
+
+            Then("message: 잔액이 없습니다") {
+                exception.reason shouldBe "잔액이 없습니다."
+            }
+        }
+
+        val balance = 1000L
+        When("잔액이 "+balance+"원 일떄 거스름돈을 반환하면") {
+            val cash = Cash.of(balance);
+            val cashReset = cash.reset();
+            val expected = cash.toCashChangeView()
+
+            every {
+                cashRepository.findFirstBy()
+            } returns Optional.of(cash)
+
+            every {
+                transactionServiceImpl.change(cash.changeReturn())
+            } returns Transaction.ofChange(cash.changeReturn())
+
+            every {
+                cashRepository.save(any())
+            } returns cashReset
+
+            val cashChangeView = cashService.change();
+            Then(""+expected.amount + "원의 잔액 결과를 반환한다.") {
+                cashChangeView.amount shouldBe expected.amount
+            }
+        }
+    }
 })


### PR DESCRIPTION
## 개요
캐시 거스름돈 api 서비스단 개발, 테스트 코드 추가, controller 정책 수정

service 시나리오를 조금 변경 했습니다.
- 이력 추가 -> cash 상태 저장

## postman api 통합 테스트
- 잔액이 없을때 
![image](https://user-images.githubusercontent.com/32861341/201107522-26db9b98-acaa-4c03-876c-3140260aaa2e.png)

- 200 일때 (잔액 1000원)
![image](https://user-images.githubusercontent.com/32861341/201107596-19031251-23a6-41a4-947b-b1668cfba156.png)

