### PR TITLE
review: cash 거스름돈 service 구현 feature

### DIFF
--- a/cash-api/src/main/java/com/example/cash/controller/CashController.java
+++ b/cash-api/src/main/java/com/example/cash/controller/CashController.java
@@ -34,10 +34,10 @@ public class CashController {
 
     /**
      * 거스름돈 반환
-     * @return
+     * @return CashChangeView
      */
     @Operation(summary = "거스름돈 반환")
-    @PutMapping(value = "/change", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/change", produces = MediaType.APPLICATION_JSON_VALUE)
     public CashChangeView cashChange() {
         return cashService.change();
     }

--- a/cash-api/src/main/java/com/example/cash/service/CashServiceImpl.java
+++ b/cash-api/src/main/java/com/example/cash/service/CashServiceImpl.java
@@ -29,6 +29,14 @@ public class CashServiceImpl implements CashService {
 
     @Override
     public CashChangeView change() {
-        return null;
+        return cashRepository.findFirstBy()
+                .map(cash -> {
+                    long change = cash.change();
+                    cashRepository.save(cash);
+                    return change;
+                }).map(change -> {
+                    transactionService.change(change);
+                    return new CashChangeView(change);
+                }).orElseThrow();
     }
 }

--- a/cash-api/src/main/java/com/example/error/exception/CashEmptyException.java
+++ b/cash-api/src/main/java/com/example/error/exception/CashEmptyException.java
@@ -6,7 +6,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 public class CashEmptyException extends ResponseStatusException {
 
-    public CashEmptyException(HttpStatus status) {
-        super(status, ErrorMessage.CASH_EMPTY);
+    public CashEmptyException() {
+        super(HttpStatus.NOT_FOUND, ErrorMessage.CASH_EMPTY);
     }
 }

--- a/cash-api/src/main/java/com/example/mongo/model/Cash.java
+++ b/cash-api/src/main/java/com/example/mongo/model/Cash.java
@@ -1,7 +1,7 @@
 package com.example.mongo.model;
 
+import com.example.cash.dto.CashChangeView;
 import com.example.cash.dto.CashDepositView;
-import com.example.error.exception.CashEmptyException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.bson.types.ObjectId;
@@ -9,7 +9,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
-import org.springframework.http.HttpStatus;
 
 import java.time.Instant;
 
@@ -42,7 +41,7 @@ public class Cash {
     private Instant updateDate;
 
     public static Cash of(long balance) {
-        return new Cash(ObjectId.get(), balance, Instant.now(), Instant.now());
+        return new Cash(null, balance, null, null);
     }
 
     private Cash copy() {
@@ -63,15 +62,18 @@ public class Cash {
     /**
      * 남은 거스름돈 반환
      *
-     * @return long
      */
-    public long change() {
-        if(balance == 0) {
-            throw new CashEmptyException(HttpStatus.NOT_FOUND);
-        }
-        long amount = balance;
-        balance = 0L;
-        return amount;
+    public Cash change() {
+        Cash cash = copy();
+        cash.balance = 0L;
+        return cash;
+    }
+
+    /**
+     * 잔고 사용여부
+     */
+    public boolean enableBalance() {
+        return balance > 0;
     }
 
     /**
@@ -79,5 +81,12 @@ public class Cash {
      */
     public CashDepositView toCashDepositView() {
         return new CashDepositView(balance);
+    }
+
+    /**
+     * 거스름돈 응답값 반환
+     */
+    public CashChangeView toCashChangeView() {
+        return new CashChangeView(balance);
     }
 }

--- a/cash-api/src/main/java/com/example/mongo/model/Cash.java
+++ b/cash-api/src/main/java/com/example/mongo/model/Cash.java
@@ -1,6 +1,7 @@
 package com.example.mongo.model;
 
 import com.example.cash.dto.CashDepositView;
+import com.example.error.exception.CashEmptyException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.bson.types.ObjectId;
@@ -8,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
+import org.springframework.http.HttpStatus;
 
 import java.time.Instant;
 
@@ -56,6 +58,20 @@ public class Cash {
         Cash cash = copy();
         cash.balance += amount;
         return cash;
+    }
+
+    /**
+     * 남은 거스름돈 반환
+     *
+     * @return long
+     */
+    public long change() {
+        if(balance == 0) {
+            throw new CashEmptyException(HttpStatus.NOT_FOUND);
+        }
+        long amount = balance;
+        balance = 0L;
+        return amount;
     }
 
     /**

--- a/cash-api/src/test/kotlin/com/example/cash/controller/CashControllerTest.kt
+++ b/cash-api/src/test/kotlin/com/example/cash/controller/CashControllerTest.kt
@@ -106,7 +106,7 @@ class CashControllerUnitTest(
         }
 
         When("자판기 잔액이 0원인 상태에서 호출 했을때") {
-            every { cashService.change() } throws CashEmptyException(HttpStatus.NOT_FOUND)
+            every { cashService.change() } throws CashEmptyException()
             val exchange = cashChangeClient().exchange()
             val expected = ErrorMessage.CASH_EMPTY
             Then("status: 404 NOT FOUND") {

--- a/cash-api/src/test/kotlin/com/example/cash/service/CashServiceTest.kt
+++ b/cash-api/src/test/kotlin/com/example/cash/service/CashServiceTest.kt
@@ -12,7 +12,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import org.springframework.http.HttpStatus
 import java.util.*
 
 class CashServiceTest : BehaviorSpec({
@@ -77,7 +76,7 @@ class CashServiceTest : BehaviorSpec({
 
     Given("cashService change 테스트") {
         When("잔액이 0원 일떄 거스름돈을 반환하면") {
-            val cash = Cash.of(0);
+            val cash = Cash.of(0)
 
             every {
                 cashRepository.findFirstBy()
@@ -85,7 +84,7 @@ class CashServiceTest : BehaviorSpec({
 
             every {
                 transactionServiceImpl.change(any())
-            } throws CashEmptyException(HttpStatus.NOT_FOUND)
+            } throws CashEmptyException()
 
             val exception = shouldThrowExactly<CashEmptyException> {
                 cashService.change()
@@ -98,8 +97,9 @@ class CashServiceTest : BehaviorSpec({
 
         val balance = 1000L
         When("잔액이 "+balance+"원 일떄 거스름돈을 반환하면") {
-            val cash = Cash.of(balance);
-            val expected = CashChangeView(balance);
+            val cash = Cash.of(balance)
+            val changeCash = cash.change()
+            val expected = CashChangeView(balance)
 
             every {
                 cashRepository.findFirstBy()
@@ -110,10 +110,10 @@ class CashServiceTest : BehaviorSpec({
             } returns Transaction.ofChange(balance)
 
             every {
-                cashRepository.save(cash)
-            } returns cash
+                cashRepository.save(changeCash)
+            } returns changeCash
 
-            val cashChangeView = cashService.change();
+            val cashChangeView = cashService.change()
             Then(""+expected.amount + "원의 잔액 결과를 반환한다.") {
                 cashChangeView.amount shouldBe expected.amount
             }


### PR DESCRIPTION
## 요약
- #115 PR에 대한 소스 리뷰
- 리뷰 보시고 의견 주시면 감사하겠습니다. 🙏 
### 예외
- CashEmptyException 객체 생성시, default status 404로 선언
### Cash
#### Entity
- 필드 변수 수정이 필요한 경우, 반드시 객체를 복사후에 처리 하는것을 추천드립니다.
- 해당 도메인에서 처리가 필요한 View 객체는, Entity 관리 클래스에서 변환 로직을 생성하는걸 추천드립니다.
- Annotation: MongoId, CreatedDate, LastModifiedDate 는 데이터 베이스 저장전에 생성되기 때문에, 
  객체 생성로직에 필요하지 않습니다.
#### Service
- 거스름돈 반환 처리 과정 수정
- CashEmptyException 는 Client - Server간 에러 발생을 정의한 예외이기 때문에, 
   Entity Layer에서 사용하는건 추천하지 않습니다.
   [Controller-Service-Repository Exception Handling-1](https://itecnotes.com/software/design-where-would-you-handle-exceptions-controller-service-repository/)
   [Controller-Service-Repository Exception Handling-2](https://vaadin.com/blog/ddd-part-3-domain-driven-design-and-the-hexagonal-architecture)




#115 