### PR TITLE
[#120] 음료수, 전시 도메인 개선

### DIFF
--- a/drink-api/build.gradle
+++ b/drink-api/build.gradle
@@ -9,3 +9,7 @@ version = 'v01'
 
 dependencies {
 }
+
+test {
+    useJUnitPlatform()
+}

--- a/drink-api/src/main/java/com/example/display/controller/DisplayController.java
+++ b/drink-api/src/main/java/com/example/display/controller/DisplayController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @RestController
@@ -28,9 +29,8 @@ public class DisplayController {
     @Operation(summary = "상품 진열")
     @GetMapping(path = "/display", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<DisplayDrinkView> drinkDisplay() {
-
         List<Display> result = displayService.getDisplayDrinks();
-        return result.stream().map(Display::toDisplayDrinkResult).collect(Collectors.toList());
+        return result.stream().map(Display::toDisplayDrinkResult).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
 }

--- a/drink-api/src/main/java/com/example/display/dto/DisplayDrinkView.java
+++ b/drink-api/src/main/java/com/example/display/dto/DisplayDrinkView.java
@@ -24,7 +24,7 @@ public class DisplayDrinkView {
     /**
      * 상품 상태
      */
-    private Status status = Status.SOLDOUT;
+    private Status status;
 
     /**
      * 상품 명

--- a/drink-api/src/main/java/com/example/display/dto/DisplayDrinkView.java
+++ b/drink-api/src/main/java/com/example/display/dto/DisplayDrinkView.java
@@ -2,7 +2,6 @@ package com.example.display.dto;
 
 import com.example.drink.enums.Status;
 import lombok.*;
-import org.bson.types.ObjectId;
 
 /**
  * 음료수 진열 응답 필드
@@ -13,9 +12,9 @@ import org.bson.types.ObjectId;
 public class DisplayDrinkView {
 
     /**
-     * 음료수 번호
+     * 음료수 물류 관리 번호
      */
-    private ObjectId drinkId;
+    private String drinkCode;
 
     /**
      * 진열 위치

--- a/drink-api/src/main/java/com/example/display/dto/DisplayDrinkView.java
+++ b/drink-api/src/main/java/com/example/display/dto/DisplayDrinkView.java
@@ -25,7 +25,7 @@ public class DisplayDrinkView {
     /**
      * 상품 상태
      */
-    private Status status;
+    private Status status = Status.SOLDOUT;
 
     /**
      * 상품 명

--- a/drink-api/src/main/java/com/example/display/repo/DisplayRepository.java
+++ b/drink-api/src/main/java/com/example/display/repo/DisplayRepository.java
@@ -15,8 +15,8 @@ public interface DisplayRepository extends MongoRepository<Display, ObjectId> {
             "{ $lookup:\n" +
             "       {\n" +
             "         from: drink,\n" +
-            "         localField: drinkId,\n" +
-            "         foreignField: _id,\n" +
+            "         localField: drinkCode,\n" +
+            "         foreignField: code,\n" +
             "         as: drinks\n" +
             "       }" +
             "}"})

--- a/drink-api/src/main/java/com/example/mongo/config/MongoInitDrinkDisplayDataRunner.java
+++ b/drink-api/src/main/java/com/example/mongo/config/MongoInitDrinkDisplayDataRunner.java
@@ -23,7 +23,7 @@ public class MongoInitDrinkDisplayDataRunner implements ApplicationRunner {
     private final DisplayRepository displayRepository;
 
     @Override
-    public void run(ApplicationArguments args) throws Exception {
+    public void run(ApplicationArguments args) {
 
         System.out.println("drink 도메인 개발모드 활성화...");
         clearData();
@@ -34,9 +34,9 @@ public class MongoInitDrinkDisplayDataRunner implements ApplicationRunner {
 
         System.out.println("drink display 컬렉션 초기화 데이터 생성중... ");
         List<Drink> drinks = List.of(
-                Drink.of("콜라", 2000, 30),
-                Drink.of("식헤", 3000, 30),
-                Drink.of("사이다", 1500, 0));
+                Drink.of("coca-cola-500ml", "코카콜라 500ml", 2000, 30),
+                Drink.of("sik-hye-500ml", "식혜 500ml", 3000, 30),
+                Drink.of("soda-pop-500ml", "사이다 500ml", 1500, 0));
 
         List<Display> displays = new ArrayList<>();
         drinkRepository.saveAll(drinks).forEach(drink -> generateDisplay(displays, drink));
@@ -48,7 +48,7 @@ public class MongoInitDrinkDisplayDataRunner implements ApplicationRunner {
     public void generateDisplay(List<Display> displays, Drink drink) {
         int position = displays.size() + 1;
         if (position > 9) return;
-        displays.add(Display.of(position, drink.getId()));
+        displays.add(Display.of(position, drink.getCode()));
     }
 
     public void clearData() {

--- a/drink-api/src/main/java/com/example/mongo/model/Display.java
+++ b/drink-api/src/main/java/com/example/mongo/model/Display.java
@@ -50,6 +50,6 @@ public class Display {
     public DisplayDrinkView toDisplayDrinkResult() {
         Drink drink = drinks.stream().findFirst().orElseThrow();
         Status status = (drink.quantity == 0) ? Status.SOLDOUT : Status.AVAILABLE;
-        return new DisplayDrinkView(id, position, status, drink.name, drink.price);
+        return new DisplayDrinkView(drink.code, position, status, drink.name, drink.price);
     }
 }

--- a/drink-api/src/main/java/com/example/mongo/model/Display.java
+++ b/drink-api/src/main/java/com/example/mongo/model/Display.java
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * 음료 전시 데이터
@@ -48,7 +49,7 @@ public class Display {
      * 전시 음료결과 데이터 변환
      */
     public DisplayDrinkView toDisplayDrinkResult() {
-        return drinks.stream().findFirst().map(this::toDisplayDrinkView).orElse(null);
+        return drinks.stream().filter(Objects::nonNull).findFirst().map(this::toDisplayDrinkView).orElse(null);
     }
 
     /**

--- a/drink-api/src/main/java/com/example/mongo/model/Display.java
+++ b/drink-api/src/main/java/com/example/mongo/model/Display.java
@@ -39,7 +39,7 @@ public class Display {
      */
     @ReadOnlyProperty
     List<Drink> drinks;
-    
+
     public static Display of(int position, String drinkCode) {
         return new Display(null, position, drinkCode, null);
     }
@@ -48,7 +48,15 @@ public class Display {
      * 전시 음료결과 데이터 변환
      */
     public DisplayDrinkView toDisplayDrinkResult() {
-        Drink drink = drinks.stream().findFirst().orElseThrow();
+        return drinks.stream().findFirst().map(this::toDisplayDrinkView).orElse(null);
+    }
+
+    /**
+     * DisplayDrinkView 변환 함수
+     *
+     * @param drink 음료수
+     */
+    private DisplayDrinkView toDisplayDrinkView(Drink drink) {
         Status status = (drink.quantity == 0) ? Status.SOLDOUT : Status.AVAILABLE;
         return new DisplayDrinkView(drink.code, position, status, drink.name, drink.price);
     }

--- a/drink-api/src/main/java/com/example/mongo/model/Display.java
+++ b/drink-api/src/main/java/com/example/mongo/model/Display.java
@@ -5,6 +5,7 @@ import com.example.drink.enums.Status;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.bson.types.ObjectId;
+import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
 
@@ -29,17 +30,18 @@ public class Display {
     int position;
 
     /**
-     * 음료 고유 번호
+     * 음료수 물류 관리 번호
      */
-    ObjectId drinkId;
+    String drinkCode;
 
     /**
-     * 음료
+     * 전시 등록된 음료수 리스트
      */
+    @ReadOnlyProperty
     List<Drink> drinks;
     
-    public static Display of(int position, ObjectId drinkId) {
-        return new Display(null, position, drinkId, null);
+    public static Display of(int position, String drinkCode) {
+        return new Display(null, position, drinkCode, null);
     }
 
     /**

--- a/drink-api/src/main/java/com/example/mongo/model/Drink.java
+++ b/drink-api/src/main/java/com/example/mongo/model/Drink.java
@@ -3,31 +3,49 @@ package com.example.mongo.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
-
-import java.util.List;
 
 @Document
 @Data
 @AllArgsConstructor
 public class Drink {
-
+    /**
+     * 음료수 번호
+     */
     @MongoId
     ObjectId id;
-    String name;
-    long price;
-    long quantity;
 
-    List<Display> displays;
+    /**
+     * 음료수 물류 관리 코드
+     */
+    @Indexed(unique = true)
+    String code;
+
+    /**
+     * 음료수 이름
+     */
+    String name;
+
+    /**
+     * 판매가격
+     */
+    long price;
+
+    /**
+     * 수량
+     */
+    long quantity;
 
     /**
      * 음료 데이터 생성
-     * @param name 이름
-     * @param price 가격
-     * @param quantity 수량
+     * @param code 음료 물류 관리 번호
+     * @param name 음료수 이름
+     * @param price 음료수 가격
+     * @param quantity 음료수 수량
      */
-    public static Drink of(String name, int price, int quantity) {
-        return new Drink(null, name, price, quantity, null);
+    public static Drink of(String code, String name, int price, int quantity) {
+        return new Drink(null, code, name, price, quantity);
     }
 }

--- a/drink-api/src/test/kotlin/com/example/display/controller/DisplayControllerTest.kt
+++ b/drink-api/src/test/kotlin/com/example/display/controller/DisplayControllerTest.kt
@@ -3,8 +3,6 @@ package com.example.display.controller
 import com.example.display.dto.DisplayDrinkView
 import com.example.display.fixture.display
 import com.example.display.service.DisplayService
-import com.example.drink.enums.Status
-import com.example.mongo.model.Display
 import com.example.mongo.model.Drink
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -15,7 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
-import reactor.core.publisher.Mono
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
@@ -30,8 +27,8 @@ class DisplayControllerTest(
                 every { displayService.displayDrinks } returns listOf((display {
                     id = ObjectId.get()
                     position = 1
-                    drinkId = ObjectId.get()
-                    drinks = listOf<Drink>(Drink.of("콜라", 1000,5))
+                    drinkCode = "coke"
+                    drinks = listOf<Drink>(Drink.of("coke", "콜라", 1000,5))
                 }))
 
                 webTestClient

--- a/drink-api/src/test/kotlin/com/example/display/fixture/DisplayBuilder.kt
+++ b/drink-api/src/test/kotlin/com/example/display/fixture/DisplayBuilder.kt
@@ -12,10 +12,10 @@ class DisplayBuilder {
 
     var id: ObjectId? = null
     var position: Int = 0
-    var drinkId: ObjectId? = null
+    var drinkCode: String? = null
     var drinks: List<Drink>? = null
 
     fun build(): Display = Display(
-        id,position,drinkId,drinks
+        id,position,drinkCode,drinks
     )
 }

--- a/drink-api/src/test/kotlin/com/example/display/repo/DisplayRepositoryTest.kt
+++ b/drink-api/src/test/kotlin/com/example/display/repo/DisplayRepositoryTest.kt
@@ -4,7 +4,6 @@ import com.example.mongo.model.Display
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import org.bson.types.ObjectId
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
 
 @DataMongoTest
@@ -13,7 +12,7 @@ class DisplayRepositoryTest(
 ):BehaviorSpec ({
 
     Given("display 데이터 1개를 생성하고") {
-        val display = Display.of(0, ObjectId.get())
+        val display = Display.of(0, "code")
         When("display 데이터 1개를 저장하면") {
             val result = displayRepository.save(display)
             Then("1개의 Display를 성공적으로 반환한다.") {
@@ -23,12 +22,12 @@ class DisplayRepositoryTest(
     }
 
     Given("display 데이터를 생성하고"){
-        val display = Display.of(0, ObjectId.get())
+        val display = Display.of(0, "code")
         displayRepository.save(display)
         When("display 데이터 1개를 삭제하면") {
             val result = displayRepository.delete(display)
             Then("성공시 void를 반환한다.") {
-                result shouldBe kotlin.Unit
+                result shouldBe Unit
             }
         }
     }

--- a/drink-api/src/test/kotlin/com/example/display/service/DisplayServiceTest.kt
+++ b/drink-api/src/test/kotlin/com/example/display/service/DisplayServiceTest.kt
@@ -7,12 +7,11 @@ import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import org.bson.types.ObjectId
 
 class DisplayServiceTest: BehaviorSpec ({
 
     val displayRepository : DisplayRepository = mockk()
-    val displayServiceImpl : DisplayServiceImpl = DisplayServiceImpl(displayRepository)
+    val displayServiceImpl = DisplayServiceImpl(displayRepository)
 
     beforeEach {
         clearAllMocks()
@@ -20,7 +19,7 @@ class DisplayServiceTest: BehaviorSpec ({
 
     Given("display와 drink의 룩업된 전체 리스트 조회 서비스") {
         When("displayServiceImpl의 displayDrinks 조회시") {
-            val expected = listOf(Display.of(1,ObjectId.get()))
+            val expected = listOf(Display.of(1, "code"))
             every {
                 displayRepository.findWithDrink()
             } returns expected

--- a/drink-api/src/test/kotlin/com/example/drink/repo/DrinkRepositoryTest.kt
+++ b/drink-api/src/test/kotlin/com/example/drink/repo/DrinkRepositoryTest.kt
@@ -10,9 +10,9 @@ import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
 class DrinkRepositoryTest(
     private val drinkRepository: DrinkRepository
 ):BehaviorSpec({
-
+    val code = "code"
     Given("drink repository 저장 테스트") {
-        val drink = Drink.of("콜라",1000,10)
+        val drink = Drink.of(code,"콜라",1000,10)
         When("콜라(drink) 상품 저장하면") {
             val result = drinkRepository.save(drink)
             Then("저장 성공시 콜라(drink)를 반환한다.") {
@@ -22,18 +22,18 @@ class DrinkRepositoryTest(
     }
 
     Given("drink repository 삭제 테스트") {
-        val drink = Drink.of("콜라", 1000, 10)
+        val drink = Drink.of(code,"콜라", 1000, 10)
             .let(drinkRepository::save)
         When("콜라(drink) 상품 삭제하면") {
             val result = drinkRepository.delete(drink)
             Then("성공시 void를 반환한다.") {
-                result shouldBe kotlin.Unit
+                result shouldBe Unit
             }
         }
     }
 
     Given("drink repository 조회 테스트") {
-        val drink = Drink.of("콜라", 1000, 10)
+        val drink = Drink.of(code,"콜라", 1000, 10)
             .let(drinkRepository::save)
         When("콜라(drink) 상품 조회하면") {
             val result = drinkRepository.findById(drink.id)


### PR DESCRIPTION
## 요약
- 음료수 물류 관리 코드가 중복되지 않는 경우, 음료수 생성이 되어야한다.
- 음료수 물류 관리 코드 변경된 경우, 실제로 음료수 정보가 변경되는 경우 `Human Error`
  - 전시에서는 음료수 번호로 조회하게 되면, 음료수 정보 변경에 관계없이 무조건 조회할수 있다.
     실제로 전시를 관리하는 의미가 사라짐
- 전시할때, 음료수 물류 관리 코드로 매핑되는 음료수가 없는 경우,  전시 데이터로 주지 않는다.
 
### Drink
- 음료수 물류 관리 코드 추가
- `List<Display> displays;` 필드 제거
### Display
- 음료수 번호 제거
- 음료수 물류 관리 코드 추가
### build.gradle
- test task 추가