### PR TITLE
[#124] 주문서(order) entitymapper 라이브러리 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
+        implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+
+        annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.testcontainers:testcontainers:1.16.3'

--- a/purchase-api/src/main/java/com/example/mongo/model/entitymapper/OrderMapper.java
+++ b/purchase-api/src/main/java/com/example/mongo/model/entitymapper/OrderMapper.java
@@ -1,0 +1,10 @@
+package com.example.mongo.model.entitymapper;
+
+import com.example.mongo.model.Order;
+import com.example.order.dto.OrderPayLoad;
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface OrderMapper {
+    Order orderPayLoadToOrder (OrderPayLoad orderPayLoad);
+}

--- a/purchase-api/src/main/java/com/example/order/service/OrderServiceImpl.java
+++ b/purchase-api/src/main/java/com/example/order/service/OrderServiceImpl.java
@@ -1,9 +1,11 @@
 package com.example.order.service;
 
 import com.example.mongo.model.Order;
+import com.example.mongo.model.entitymapper.OrderMapper;
 import com.example.order.dto.OrderPayLoad;
 import com.example.order.repo.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import org.mapstruct.factory.Mappers;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,9 +14,11 @@ public class OrderServiceImpl implements OrderService {
 
     private final OrderRepository orderRepository;
 
+    private OrderMapper orderMapper = Mappers.getMapper(OrderMapper.class);
+
     @Override
     public Order registerBy(OrderPayLoad orderPayLoad) {
-        Order order = Order.of(orderPayLoad);
+        Order order = orderMapper.orderPayLoadToOrder(orderPayLoad);
         return orderRepository.save(order);
     }
 }

--- a/purchase-api/src/test/kotlin/com/example/mongo/model/entitymapper/OrderMapperTest.kt
+++ b/purchase-api/src/test/kotlin/com/example/mongo/model/entitymapper/OrderMapperTest.kt
@@ -1,0 +1,23 @@
+package com.example.mongo.model.entitymapper
+
+import com.example.mongo.model.Order
+import com.example.order.dto.OrderPayLoad
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.mapstruct.factory.Mappers
+
+class OrderMapperTest(
+
+) : BehaviorSpec({
+
+    Given("order entity mapper 테스트") {
+        val orderMapper : OrderMapper = Mappers.getMapper(OrderMapper::class.java)
+        When("payload를 entityMapper를 통해 entity로 변환에 성공하면") {
+            val payload = OrderPayLoad("coca-cola-500ml","콜라",2000L)
+            val order : Order = orderMapper.orderPayLoadToOrder(payload)
+            Then("order entity객체의 drinkCode는 " + payload.drinkCode + "와 같다") {
+                order.drinkCode shouldBe payload.drinkCode
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 정리
1. entitymapper 이용시 파라미터로 받은 객체의 getter/setter를 활용하여 변환대상의 pojo 필드 객체에 값을 집어넣는다. (필드가 없으면 해당 필드에 값은 전달하지 못하므로 null 값이 된다.)
2. 서로 다른 필드 이름을 가진 pojo객체를 매핑시킬때는  어노테이션으로 명시해줘야함(#124 doc 참고)