### PR TITLE
[#142] cash&transaction 도메인 entitymapper 적용

### DIFF
--- a/cash-api/src/main/java/com/example/mongo/model/Cash.java
+++ b/cash-api/src/main/java/com/example/mongo/model/Cash.java
@@ -1,7 +1,5 @@
 package com.example.mongo.model;
 
-import com.example.cash.dto.CashChangeView;
-import com.example.cash.dto.CashDepositView;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.bson.types.ObjectId;
@@ -44,58 +42,10 @@ public class Cash {
         return new Cash(null, balance, null, null);
     }
 
-    private Cash copy() {
-        return new Cash(id, balance, createDate, updateDate);
-    }
-
-    /**
-     * 입금하기
-     *
-     * @param amount 금액
-     */
-    public Cash deposit(long amount) {
-        Cash cash = copy();
-        cash.balance += amount;
-        return cash;
-    }
-
-    /**
-     * 남은 거스름돈 반환
-     *
-     */
-    public Cash change() {
-        Cash cash = copy();
-        cash.balance = 0L;
-        return cash;
-    }
-
-    /**
-     * 입금 금액 사용
-     * @param amount 금액
-     */
-    public Cash charge(Long amount) {
-        Cash cash = copy();
-        cash.balance -= amount;
-        return cash;
-    }
     /**
      * 잔고 사용여부
      */
     public boolean enableBalance() {
         return balance > 0;
-    }
-
-    /**
-     * 입금 응답값 변환
-     */
-    public CashDepositView toCashDepositView() {
-        return new CashDepositView(balance);
-    }
-
-    /**
-     * 거스름돈 응답값 반환
-     */
-    public CashChangeView toCashChangeView() {
-        return new CashChangeView(balance);
     }
 }

--- a/cash-api/src/main/java/com/example/mongo/model/Transaction.java
+++ b/cash-api/src/main/java/com/example/mongo/model/Transaction.java
@@ -44,41 +44,4 @@ public class Transaction {
      */
     @LastModifiedDate
     private Instant updateDate;
-
-    /**
-     * 거래 내역 생성
-     *
-     * @param type   거래 구분
-     * @param amount 거래 내역금액
-     */
-    private static Transaction of(TransactionType type, Long amount) {
-        return new Transaction(null, type, amount, null, null);
-    }
-
-    /**
-     * 거래 입금 내역 생성
-     *
-     * @param amount 거래 입금 금액
-     */
-    public static Transaction ofDeposit(Long amount) {
-        return of(TransactionType.DEPOSIT, amount);
-    }
-
-    /**
-     * 거스름돈 반환 내역 생성
-     *
-     * @param amount 거스름돈 반환 금액
-     */
-    public static Transaction ofChange(Long amount) {
-        return of(TransactionType.CHANGE, amount);
-    }
-
-    /**
-     * 입금 금액 사용
-     *
-     * @param amount 사용한 금액
-     */
-    public static Transaction ofCharge(Long amount) {
-        return of(TransactionType.CHARGE, amount);
-    }
 }

--- a/cash-api/src/main/java/com/example/mongo/model/entitymapper/CashMapper.java
+++ b/cash-api/src/main/java/com/example/mongo/model/entitymapper/CashMapper.java
@@ -1,0 +1,42 @@
+package com.example.mongo.model.entitymapper;
+
+import com.example.cash.dto.CashChangeView;
+import com.example.cash.dto.CashDepositView;
+import com.example.mongo.model.Cash;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {})
+public interface CashMapper {
+
+    CashDepositView CashToCashDepositView(Cash cash);
+
+    @Mapping(target="amount", source="cash.balance")
+    CashChangeView CashToCashChangeView(Cash cash);
+
+
+    /**
+     * 입금하기
+     * @param cash 캐시정보
+     * @param amount 금액
+     * @return Cash
+     */
+    @Mapping(target="balance", expression = "java(cash.getBalance() + amount )")
+    Cash deposit(Cash cash,Long amount);
+
+
+    /**
+     * 남은 거스름돈 반환
+     * @param cash 캐시정보
+     * @return Cash
+     */
+    @Mapping(target="balance", constant = "0L")
+    Cash change(Cash cash);
+
+    /**
+     * 입금 금액 사용
+     * @param amount 금액
+     */
+    @Mapping(target = "balance", expression = "java(cash.getBalance() - amount)")
+    Cash charge(Cash cash,Long amount);
+}

--- a/cash-api/src/main/java/com/example/mongo/model/entitymapper/CashMapper.java
+++ b/cash-api/src/main/java/com/example/mongo/model/entitymapper/CashMapper.java
@@ -3,40 +3,49 @@ package com.example.mongo.model.entitymapper;
 import com.example.cash.dto.CashChangeView;
 import com.example.cash.dto.CashDepositView;
 import com.example.mongo.model.Cash;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring", uses = {})
 public interface CashMapper {
 
     CashDepositView CashToCashDepositView(Cash cash);
 
-    @Mapping(target="amount", source="cash.balance")
+    @Mapping(target = "amount", source = "cash.balance")
     CashChangeView CashToCashChangeView(Cash cash);
-
 
     /**
      * 입금하기
      * @param cash 캐시정보
      * @param amount 금액
-     * @return Cash
      */
-    @Mapping(target="balance", expression = "java(cash.getBalance() + amount )")
-    Cash deposit(Cash cash,Long amount);
+    @Mapping(target = "balance",source = "amount", qualifiedByName = "increaseBalance")
+    Cash deposit(@Context Cash cash, Long amount);
 
 
     /**
      * 남은 거스름돈 반환
      * @param cash 캐시정보
-     * @return Cash
      */
-    @Mapping(target="balance", constant = "0L")
+    @Mapping(target = "balance", constant = "0L")
     Cash change(Cash cash);
 
     /**
      * 입금 금액 사용
      * @param amount 금액
      */
-    @Mapping(target = "balance", expression = "java(cash.getBalance() - amount)")
-    Cash charge(Cash cash,Long amount);
+    @Mapping(target = "balance",source = "amount", qualifiedByName = "decreaseBalance")
+    Cash charge(@Context Cash cash, Long amount);
+
+    @Named("decreaseBalance")
+    default Long decreaseBalance(@Context Cash cash, Long amount) {
+        return cash.getBalance() - amount;
+    }
+
+    @Named("increaseBalance")
+    default Long increaseBalance(@Context Cash cash, Long amount) {
+        return cash.getBalance() + amount;
+    }
 }

--- a/cash-api/src/main/java/com/example/mongo/model/entitymapper/TransactionMapper.java
+++ b/cash-api/src/main/java/com/example/mongo/model/entitymapper/TransactionMapper.java
@@ -1,0 +1,35 @@
+package com.example.mongo.model.entitymapper;
+
+import com.example.mongo.model.Transaction;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {})
+public interface TransactionMapper {
+
+    /**
+     * 거래 입금 내역 생성
+     *
+     * @param amount 거래 내역금액
+     * @return Transaction
+     */
+    @Mapping(target = "type", expression = "java(TransactionType.DEPOSIT)")
+    Transaction ofDeposit(Long amount);
+
+    /**
+     * 거스름돈 반환 내역 생성
+     *
+     * @param amount 거스름돈 반환 금액
+     * @return Transaction
+     */
+    @Mapping(target = "type", expression = "java(TransactionType.CHANGE)")
+    Transaction ofChange(Long amount);
+
+    /**
+     * 입금 금액 사용
+     * @param amount 사용한 금액
+     * @return Transaction
+     */
+    @Mapping(target = "type", expression = "java(TransactionType.CHARGE)")
+    Transaction ofCharge(Long amount);
+}

--- a/cash-api/src/main/java/com/example/transaction/service/TransactionServiceImpl.java
+++ b/cash-api/src/main/java/com/example/transaction/service/TransactionServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.transaction.service;
 
 import com.example.mongo.model.Transaction;
+import com.example.mongo.model.entitymapper.TransactionMapper;
 import com.example.transaction.repo.TransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,17 +12,19 @@ public class TransactionServiceImpl implements TransactionService {
 
     private final TransactionRepository transactionRepository;
 
+    private final TransactionMapper transactionMapper;
+
     @Override
     public Transaction deposit(Long amount) {
-        return transactionRepository.save(Transaction.ofDeposit(amount));
+        return transactionRepository.save(transactionMapper.ofDeposit(amount));
     }
 
     @Override
     public Transaction change(Long amount) {
-        return transactionRepository.save(Transaction.ofChange(amount));
+        return transactionRepository.save(transactionMapper.ofChange(amount));
     }
 
     @Override
-    public Transaction charge(Long amount) {return transactionRepository.save(Transaction.ofCharge(amount));}
+    public Transaction charge(Long amount) {return transactionRepository.save(transactionMapper.ofCharge(amount));}
 
 }

--- a/cash-api/src/test/kotlin/com/example/cash/repo/CashRepositoryTest.kt
+++ b/cash-api/src/test/kotlin/com/example/cash/repo/CashRepositoryTest.kt
@@ -57,6 +57,7 @@ class CashRepositoryTest(
 
     Given("cash 데이터가 db에 존재하지 않을떄") {
         When("cash 데이터를 조회하면") {
+            cashRepository.deleteAll()
             val cash : Optional<Cash> = cashRepository.findFirstBy()
             Then("Optional.empty 상태를 반환한다.") {
                 cash shouldBe Optional.empty()

--- a/cash-api/src/test/kotlin/com/example/transaction/repo/TransactionRepositoryTest.kt
+++ b/cash-api/src/test/kotlin/com/example/transaction/repo/TransactionRepositoryTest.kt
@@ -1,9 +1,10 @@
 package com.example.transaction.repo
 
-import com.example.mongo.model.Transaction
 import com.example.mongo.model.TransactionType
+import com.example.mongo.model.entitymapper.TransactionMapper
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import org.mapstruct.factory.Mappers
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
 
 @DataMongoTest
@@ -11,10 +12,12 @@ class TransactionRepositoryTest(
     private val transactionRepository: TransactionRepository
 ) : BehaviorSpec({
 
+    val transactionMapper : TransactionMapper =  Mappers.getMapper(TransactionMapper::class.java)
+
     Given("거래 내역 데이터 저장") {
         When("입금 거래 내역인 경우") {
             transactionRepository.deleteAll()
-            val expected = Transaction.ofDeposit(500)
+            val expected = transactionMapper.ofDeposit(500)
             val result = transactionRepository.save(expected)
             Then("`type = DEPOSIT` 이다") {
                 result.type shouldBe TransactionType.DEPOSIT
@@ -25,7 +28,7 @@ class TransactionRepositoryTest(
     Given("거래 내역 데이터 조회") {
         When("입금 거래 내역인 경우") {
             transactionRepository.deleteAll()
-            val expected = Transaction.ofDeposit(500)
+            val expected = transactionMapper.ofDeposit(500)
             transactionRepository.save(expected)
             val result = transactionRepository.findAll()
             Then("거래 내역 리스트 개수는 1개이다") {

--- a/cash-api/src/test/kotlin/com/example/transaction/service/TransactionServiceTest.kt
+++ b/cash-api/src/test/kotlin/com/example/transaction/service/TransactionServiceTest.kt
@@ -1,6 +1,7 @@
 package com.example.transaction.service
 
 import com.example.mongo.model.TransactionType
+import com.example.mongo.model.entitymapper.TransactionMapper
 import com.example.transaction.fixture.transaction
 import com.example.transaction.repo.TransactionRepository
 import io.kotest.core.spec.style.BehaviorSpec
@@ -8,11 +9,13 @@ import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import org.mapstruct.factory.Mappers
 
 class TransactionServiceTest : BehaviorSpec({
 
     val transactionRepository: TransactionRepository = mockk()
-    val transactionServiceImpl = TransactionServiceImpl(transactionRepository)
+    val transactionMapper : TransactionMapper =  Mappers.getMapper(TransactionMapper::class.java)
+    val transactionServiceImpl = TransactionServiceImpl(transactionRepository,transactionMapper)
 
     beforeEach {
         clearAllMocks()

--- a/purchase-api/src/main/java/com/example/mongo/model/entitymapper/OrderMapper.java
+++ b/purchase-api/src/main/java/com/example/mongo/model/entitymapper/OrderMapper.java
@@ -4,7 +4,7 @@ import com.example.mongo.model.Order;
 import com.example.order.dto.OrderPayLoad;
 import org.mapstruct.Mapper;
 
-@Mapper
+@Mapper(componentModel = "spring", uses = {})
 public interface OrderMapper {
     Order orderPayLoadToOrder (OrderPayLoad orderPayLoad);
 }

--- a/purchase-api/src/main/java/com/example/order/service/OrderServiceImpl.java
+++ b/purchase-api/src/main/java/com/example/order/service/OrderServiceImpl.java
@@ -5,7 +5,6 @@ import com.example.mongo.model.entitymapper.OrderMapper;
 import com.example.order.dto.OrderPayLoad;
 import com.example.order.repo.OrderRepository;
 import lombok.RequiredArgsConstructor;
-import org.mapstruct.factory.Mappers;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,7 +13,7 @@ public class OrderServiceImpl implements OrderService {
 
     private final OrderRepository orderRepository;
 
-    private OrderMapper orderMapper = Mappers.getMapper(OrderMapper.class);
+    private final OrderMapper orderMapper;
 
     @Override
     public Order registerBy(OrderPayLoad orderPayLoad) {

--- a/purchase-api/src/test/kotlin/com/example/order/service/OrderServiceImplTest.kt
+++ b/purchase-api/src/test/kotlin/com/example/order/service/OrderServiceImplTest.kt
@@ -1,6 +1,7 @@
 package com.example.order.service
 
 import com.example.mongo.model.Order
+import com.example.mongo.model.entitymapper.OrderMapper
 import com.example.order.dto.OrderPayLoad
 import com.example.order.fixture.order
 import com.example.order.repo.OrderRepository
@@ -9,6 +10,7 @@ import io.kotest.matchers.types.shouldBeTypeOf
 import io.mockk.every
 import io.mockk.mockk
 import org.bson.types.ObjectId
+import org.mapstruct.factory.Mappers
 import java.time.Instant
 
 class OrderServiceImplTest(
@@ -16,7 +18,8 @@ class OrderServiceImplTest(
 ) : BehaviorSpec({
 
     val orderRepository : OrderRepository = mockk()
-    val orderServiceImpl =  OrderServiceImpl(orderRepository)
+    val orderMapper : OrderMapper = Mappers.getMapper(OrderMapper::class.java)
+    val orderServiceImpl =  OrderServiceImpl(orderRepository,orderMapper)
 
     val code = "002010"
     val drinkName = "콜라"


### PR DESCRIPTION
## 개요
- transaction & cash 도메인 entitymapper 도입 , 기존 로직 수정

1. mapper의 `expression` 을 활용한 필드 값 변경
2. cash 도메인쪽은 입금등의 메서드 대체시 cash의 getter 를 호출을 하기 어려운거 같아서 파라미터로 cash를 받았습니다.